### PR TITLE
Updated License details for  ibmz-accelerated-for-nvidia-triton-inference-server 1.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,7 +1640,7 @@ Information regarding technical support can be found
 
 The International License Agreement for Non-Warranted Programs (ILAN) agreement
 can be found
-[here](https://www.ibm.com/support/customer/csol/terms/?id=L-JXNY-4LLR96&lc=en) 
+[here](https://www.ibm.com/support/customer/csol/terms/?id=L-CMSD-YF5T8W&lc=en) 
 
 The registered trademark Linux® is used pursuant to a sublicense from the Linux
 Foundation, the exclusive licensee of Linus Torvalds, owner of the mark on a


### PR DESCRIPTION
Updated License details for ibmz-accelerated-for-nvidia-triton-inference-server 1.6.0 release